### PR TITLE
Fix task and user modals

### DIFF
--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -30,7 +30,7 @@ class TaskService:
         try:
             task.created_at = datetime.now()
             task.created_by = current_user
-            new_task = db.session.add(task)
+            db.session.add(task)
             db.session.commit()
             return task.id
         except Exception as e:

--- a/src/templates/modals/task_modal.html
+++ b/src/templates/modals/task_modal.html
@@ -19,7 +19,6 @@ href="{{ url_for('static', filename='css/modal.css') }}"
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="task_modalLabel">
-          {% if is_edit %}Edit User{% else %}Create User{% endif %}
         </h5>
         <button
           type="button"
@@ -87,18 +86,23 @@ href="{{ url_for('static', filename='css/modal.css') }}"
   $(document).ready(function () {
     $("#taskModal").on("shown.bs.modal", function () {
       const task = $("#taskModal").data("task");
-      const isEdit = $("#taskModal").data("is-edit"); 
+      const isEdit = $("#taskModal").data("isEdit"); 
+      // set the title of the modal
+      let text = isEdit ? "Edit Task" : "Create Task";
+      document.getElementById('task_modalLabel').innerText = text;
+      // set the values of the form
       $("#title").val(task?.title);
       $("#description").val(task?.description);
       $("#status").val(task?.status);
       $("#is_edit").val(isEdit);
+      // set the action of the form to the correct url once the user is provided
       if(isEdit){
         document.getElementById('taskForm').action = "/task/" + task.id + "/update";      
       }else {
         document.getElementById('taskForm').action = "/task/create";
-      }
-      // set the action of the form to the correct url once the user is provided 
+      } 
     
+      // set the user select options
       $.getJSON("/users/search", function (data) {
         var $userSelect = $("#user");
         $userSelect.empty();

--- a/src/templates/modals/user_modal.html
+++ b/src/templates/modals/user_modal.html
@@ -142,7 +142,10 @@
     field.readOnly = !isEdit;
   });
   const formSelect = document.querySelector('#userModal form select');
-  formSelect.disabled = !isEdit;
+  if(formSelect){
+    formSelect.disabled = !isEdit;
+
+  }
 
   if(isEdit && isSelf) {
     $('#passwordFields').show();
@@ -154,7 +157,7 @@
   if (isEdit) {
     $('#saveButton').show();
     $('#editButton').hide();
-  } else if (isAdmin) {
+  } else if (isAdmin || isSelf) {
     $('#editButton').show();
     $('#saveButton').hide();
     $('#okButton').hide();

--- a/src/templates/pages/task_list.html
+++ b/src/templates/pages/task_list.html
@@ -22,7 +22,7 @@
     </thead>
     <tbody>
         {% for task in tasks %}
-        <tr data-toggle="modal" data-target="#taskModal">
+        <tr>
           <th scope="row">{{task.id}}</th>
           <td class="task-title"><span>{{task.title}}</span></td>
           <td>{{task.status}}</td>
@@ -109,6 +109,7 @@
               success: function (result) {
                 if (result) {
                   $('#taskModal').data('task', result);
+                  $('#taskModal').data('isEdit', isEdit);
                   $('#taskModal').modal('show');
                 }
               }


### PR DESCRIPTION
This pull request fixes the task and user modals by making the following changes:

- Removed unnecessary line in the create_task function

- Updated the title of the task modal based on whether it is an edit or create operation

- Set the action of the task form to the correct URL

- Disabled the user select options if it is not an edit operation

- Showed the password fields if the user is editing their own profile

- Updated the buttons visibility based on user role and edit operation

- Removed the data-toggle and data-target attributes from the task table rows